### PR TITLE
fix(indexer): don't panic when failed to get ethereum block timestamp

### DIFF
--- a/apps/indexer/src/ethereum_indexer/indexer.rs
+++ b/apps/indexer/src/ethereum_indexer/indexer.rs
@@ -290,7 +290,7 @@ where
 
     async fn process_pending_withdraws(&self, block_number: u64) -> Result<()> {
         let pendings = self.store.get_pending_withdraws().await?;
-        let timestamp = self.client.get_block_timestamp(block_number).await;
+        let timestamp = self.client.get_block_timestamp(block_number).await?;
         for pending in pendings {
             let status = self
                 .client


### PR DESCRIPTION
Prevent ethereum indexing thread to panic when retrieving block id from provider failed.
