### PR TITLE
fix(indexer): fix string format for request hash 

### DIFF
--- a/apps/indexer/src/starknet_indexer/events.rs
+++ b/apps/indexer/src/starknet_indexer/events.rs
@@ -142,7 +142,7 @@ fn u256_to_hex(felts: &[FieldElement]) -> Result<String> {
         return Err(anyhow!("At least two felts are required to read a u256"));
     }
 
-    Ok(format!("{:#032x}{:032x}", felts[1], felts[0]))
+    Ok(format!("0x{:032x}{:032x}", felts[1], felts[0]))
 }
 
 ///


### PR DESCRIPTION
We have a different string format to represent request hash in ethereum and starknet which could lead to missing event.
