### PR TITLE
feat(starknet): ERC721 uri, bridge ownership and collection white list

### DIFF
--- a/apps/blockchain/starknet/src/bridge.cairo
+++ b/apps/blockchain/starknet/src/bridge.cairo
@@ -29,6 +29,7 @@ mod bridge {
         CollectionDeployedFromL1,
         ReplacedClassHash,
         BridgeEnabled,
+        CollectionWhiteListUpdated,
     };
 
     use starklane::request::{
@@ -108,6 +109,7 @@ mod bridge {
         WithdrawRequestCompleted: WithdrawRequestCompleted,
         ReplacedClassHash: ReplacedClassHash,
         BridgeEnabled: BridgeEnabled,
+        CollectionWhiteListUpdated: CollectionWhiteListUpdated,
         #[flat]
         OwnableEvent: OwnableComponent::Event,
     }
@@ -315,6 +317,10 @@ mod bridge {
         fn white_list_collection(ref self: ContractState, collection: ContractAddress, enabled: bool) {
             ensure_is_admin(@self);
             _white_list_collection(ref self, collection, enabled);
+            self.emit(CollectionWhiteListUpdated {
+                collection,
+                enabled,
+            });
         }
 
         fn is_white_listed(self: @ContractState, collection: ContractAddress) -> bool {
@@ -465,6 +471,10 @@ mod bridge {
         let (already_white_listed, _) = self.white_listed_list.read(l2_addr_from_deploy);
         if already_white_listed != true {
             _white_list_collection(ref self, l2_addr_from_deploy, true);
+            self.emit(CollectionWhiteListUpdated {
+                collection: l2_addr_from_deploy,
+                enabled: true,
+            });
         }
         l2_addr_from_deploy
     }

--- a/apps/blockchain/starknet/src/interfaces.cairo
+++ b/apps/blockchain/starknet/src/interfaces.cairo
@@ -28,6 +28,7 @@ trait IStarklane<T> {
     fn is_white_list_enabled(self: @T) -> bool;
     fn white_list_collection(ref self: T, collection: ContractAddress, enabled: bool);
     fn is_white_listed(self: @T, collection: ContractAddress) -> bool;
+    fn get_white_listed_collections(self: @T) -> Span<ContractAddress>;
 
     fn enable(ref self: T, enable: bool);
     fn is_enabled(self: @T) -> bool;

--- a/apps/blockchain/starknet/src/interfaces.cairo
+++ b/apps/blockchain/starknet/src/interfaces.cairo
@@ -100,3 +100,10 @@ struct L1L2CollectionMappingUpdated {
     #[key]
     collection_l2: ContractAddress
 }
+
+#[derive(Drop, starknet::Event)]
+struct CollectionWhiteListUpdated {
+    #[key]
+    collection: ContractAddress,
+    enabled: bool,
+} 

--- a/apps/blockchain/starknet/src/token/interfaces.cairo
+++ b/apps/blockchain/starknet/src/token/interfaces.cairo
@@ -14,6 +14,13 @@ trait IERC721<T> {
 }
 
 #[starknet::interface]
+trait IERC721Uri<T> {
+    fn base_uri(self: @T) -> ByteArray;
+    fn set_base_uri(ref self: T, base_uri: ByteArray);
+    fn set_token_uri(ref self: T, token_id: u256, token_uri: ByteArray);
+}
+
+#[starknet::interface]
 trait IERC721Mintable<T> {
     fn mint(ref self: T, to: ContractAddress, token_id: u256);
     fn mint_range(ref self: T, to: ContractAddress, start: u256, end: u256);


### PR DESCRIPTION
This PR provide the following features for starknet smart contracts:
- `set_base_uri` and `set_token_uri` in `ERC721Bridgeable`
- OZ two steps Ownable implementation for bridge
- retrieving list of white listed collections

