### PR TITLE
Fix : #234 Missing checks for address(0x0) when updating address stat…

### DIFF
--- a/apps/blockchain/ethereum/src/Bridge.sol
+++ b/apps/blockchain/ethereum/src/Bridge.sol
@@ -261,7 +261,12 @@ contract Starklane is IStarklaneEvent, UUPSOwnableProxied, StarklaneState, Stark
         address collectionL1 = req.collectionL1;
         for (uint256 i = 0; i < req.tokenIds.length; i++) {
             uint256 id = req.tokenIds[i];
-            _withdrawFromEscrow(ctype, collectionL1, req.ownerL1, id);
+                // Attempt to withdraw from escrow and check if it was successful
+             bool _waswithdrawFromEscrow =  _withdrawFromEscrow(ctype, collectionL1, req.ownerL1, id);
+              if(! _waswithdrawFromEscrow){
+            // Revert the transaction with a message if escrow withdrawal fails
+             revert("Escrow withdrawal failed for token ID");
+           }
         }
     }
 
@@ -370,6 +375,8 @@ contract Starklane is IStarklaneEvent, UUPSOwnableProxied, StarklaneState, Stark
         snaddress collectionL2,
         bool force
     ) external onlyOwner {
+            require( collectionL1 != address(0x0), "Invalid L1 address");
+           require(snaddress.unwrap(collectionL2) != 0, "Invalid L2 address");
         _setL1L2AddressMapping(collectionL1, collectionL2, force);
         emit L1L2CollectionMappingUpdated(collectionL1, snaddress.unwrap(collectionL2));
     }

--- a/apps/blockchain/ethereum/src/Bridge.sol
+++ b/apps/blockchain/ethereum/src/Bridge.sol
@@ -262,11 +262,7 @@ contract Starklane is IStarklaneEvent, UUPSOwnableProxied, StarklaneState, Stark
         for (uint256 i = 0; i < req.tokenIds.length; i++) {
             uint256 id = req.tokenIds[i];
                 // Attempt to withdraw from escrow and check if it was successful
-             bool _waswithdrawFromEscrow =  _withdrawFromEscrow(ctype, collectionL1, req.ownerL1, id);
-              if(! _waswithdrawFromEscrow){
-            // Revert the transaction with a message if escrow withdrawal fails
-             revert("Escrow withdrawal failed for token ID");
-           }
+             _withdrawFromEscrow(ctype, collectionL1, req.ownerL1, id);
         }
     }
 

--- a/apps/blockchain/ethereum/src/Bridge.sol
+++ b/apps/blockchain/ethereum/src/Bridge.sol
@@ -261,7 +261,6 @@ contract Starklane is IStarklaneEvent, UUPSOwnableProxied, StarklaneState, Stark
         address collectionL1 = req.collectionL1;
         for (uint256 i = 0; i < req.tokenIds.length; i++) {
             uint256 id = req.tokenIds[i];
-                // Attempt to withdraw from escrow and check if it was successful
              _withdrawFromEscrow(ctype, collectionL1, req.ownerL1, id);
         }
     }

--- a/apps/blockchain/ethereum/test/Bridge.t.sol
+++ b/apps/blockchain/ethereum/test/Bridge.t.sol
@@ -29,6 +29,10 @@ contract BridgeTest is Test, IStarklaneEvent {
     address erc1155C1;
     address snCore;
 
+    address collectionL1= address(0x1);
+    snaddress collectionL2 = Cairo.snaddressWrap(0x2);
+
+
     address payable internal alice;
     address payable internal bob;
 
@@ -599,6 +603,32 @@ contract BridgeTest is Test, IStarklaneEvent {
         ( ,uint256[] memory reqContent) = abi.decode(depositRequestEvent.data, (uint256, uint256[]));
         assert(payload.length == reqContent.length);
         return (nonce, payload);
+    }
+     
+    // here is test   for set L1 L2 collection 
+   
+    function test_SetL1L2CollectionMapping() public {
+    
+        // Check for the event emission
+        vm.expectEmit(true, true, true, true);
+        emit L1L2CollectionMappingUpdated(collectionL1, snaddress.unwrap(collectionL2));
+       IStarklane(bridge).setL1L2CollectionMapping(collectionL1, collectionL2, false);
+    }
+
+    function testInvalidL1Address() public {
+        vm.expectRevert("Invalid L1 address");
+       IStarklane(bridge).setL1L2CollectionMapping(address(0), collectionL2, false);
+    }
+
+    function testInvalidL2Address() public {
+        vm.expectRevert("Invalid L2 address");
+        IStarklane(bridge).setL1L2CollectionMapping(collectionL1, Cairo.snaddressWrap(0), false);
+    }
+
+    function testInvalidUnwrappedL2Address() public {
+        snaddress invalidCollectionL2 = Cairo.snaddressWrap(0x0); 
+        vm.expectRevert("Invalid L2 address");
+        IStarklane(bridge).setL1L2CollectionMapping(collectionL1, invalidCollectionL2, false);
     }
 
 }


### PR DESCRIPTION
…e variables

Summary of Changes Made
Input Validation in setL1L2CollectionMapping:
Added checks to ensure collectionL1 is not address(0) and collectionL2 is not 0 to prevent invalid mappings. Event Emission:
Emitted L1L2CollectionMappingUpdated after setting the mapping for transparency.