### PR TITLE
fix: NFTs metadatas retrieving from API marketplace

### DIFF
--- a/apps/web/src/server/api/helpers/l2nfts.ts
+++ b/apps/web/src/server/api/helpers/l2nfts.ts
@@ -107,9 +107,8 @@ export async function getL2NftsMetadataBatch(
   for (const token of tokens) {
     const url = `${nftApiUrl}/tokens/${token.contract_address}/0x534e5f4d41494e/${token.token_id}`;
     const nftsResponse = await fetch(url, {
-      body,
       headers: requestsHeader,
-      method: "POST",
+      method: "GET",
     });
 
     const response = (await nftsResponse.json()) as TokenApiResponse;


### PR DESCRIPTION
Use /GET instead of /POST to retrieve NFTs metadata from API marketplace
